### PR TITLE
Install to $PROGRAMFILES

### DIFF
--- a/nsis-installer.nsi
+++ b/nsis-installer.nsi
@@ -24,7 +24,7 @@ Name "Borg Backup ${VERSION}"
 OutFile "Borg Backup Installer v${VERSION}.exe"
 
 ; The default installation directory
-InstallDir "C:\Program Files\Borg"
+InstallDir "$PROGRAMFILES\Borg"
 
 ; Registry key to check for directory (so if you install again, it will
 ; overwrite the old one automatically)


### PR DESCRIPTION
This pull request changes the installer script to detect the program files directory at runtime, instead of hardcoding `C:\Program Files` as the installation directory.

See http://nsis.sourceforge.net/Reference/$PROGRAMFILES for reference.