### PR TITLE
Add /tmp entry to /etc/fstab

### DIFF
--- a/fstab
+++ b/fstab
@@ -5,4 +5,5 @@
 #    see https://cygwin.com/cygwin-ug-net/using.html#mount-table
 
 # BORG INSTALLER: moved drive mount point from /cygdrive to /
-none / cygdrive binary,posix=0,user 0 0
+none /    cygdrive binary,posix=0,user  0 0
+none /tmp usertemp binary,posix=0,noacl 0 0


### PR DESCRIPTION
This pull request adds a `/tmp` entry to `/etc/fstab`.

Currently, `/tmp` defaults to `C:\Program Files\Borg\tmp`, which is of course not writable.

Since a lot of programs rely on being able to write to `$TMP` and the default cygwin `/etc/profile` sets `$TMP` to `/tmp`, this needs to be fixed in order to get a usable cygwin installation.